### PR TITLE
feat: add Concur's GitHub to the addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Updates are handled automatically.
 
 <img src="docs/screenshot-1.15-popup.png" width="320" alt="Screenshot of Popup" title="Screenshot of Popup" /> <img src="docs/screenshot-1.15-popup-config.png" width="320" alt="Screenshot of Configuration in Popup" title="Screenshot of Configuration in Popup" />
 
-* **GitHub** (`github.wdf.sap.corp` / `github.tools.sap`)
+* **GitHub** (`github.wdf.sap.corp` / `github.tools.sap` / `github.concur.com`)
   * sign in automatically
   * hide yellow notice box messages
     * dismiss a specific message

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,8 @@
     {
       "matches": [
         "*://github.wdf.sap.corp/*",
-        "*://github.tools.sap/*"
+        "*://github.tools.sap/*",
+        "*://github.concur.com/*"
       ],
       "js": [
         "utils/browser-setup.js",
@@ -51,7 +52,8 @@
     "*://fiorilaunchpad.sap.com/sap/fiori/lunchmenu/*",
     "*://people.wdf.sap.corp/*",
     "*://github.wdf.sap.corp/*",
-    "*://github.tools.sap/*"
+    "*://github.tools.sap/*",
+    "*://github.concur.com/*"
   ],
   "background": {
     "scripts": [


### PR DESCRIPTION
Now everyone in SAP has access to that new github instance, which means the users will have an i-number instead of the name.

I wonder how the people.wdf call works? I couldn't find how it is being used, but that'd be a problem because the people using github.concur rarely have ready-access to the people.wdf webite.