### PR TITLE
Sometimes text is directly after the user icon w/o separate html tag

### DIFF
--- a/content_scripts/github/username.js
+++ b/content_scripts/github/username.js
@@ -512,8 +512,7 @@ function getDirectParentOfText(baseElement, text) {
         baseElement.childNodes[1].textContent.trim() === text
     ) {
         return replaceTextNodeWithDomElementForUsername(baseElement, 1);
-    }
-    else if (
+    } else if (
         baseElement.childNodes.length === 3 &&
         baseElement.childNodes[0].nodeName === "#text" &&
         baseElement.childNodes[1].nodeName === "IMG" &&

--- a/content_scripts/github/username.js
+++ b/content_scripts/github/username.js
@@ -504,14 +504,22 @@ function getDirectParentOfText(baseElement, text) {
     if (baseElement.childNodes.length === 1 && baseElement.firstChild.nodeName === "#text" && baseElement.textContent.trim() === text) {
         return baseElement;
     } else if (
+        // sometimes text is directly after the user icon w/o separate html tag
+        // however, a real element is needed (not only a text node; a data-attribute will be set on the element later)
+        baseElement.childNodes.length === 2 &&
+        baseElement.childNodes[0].nodeName === "IMG" &&
+        baseElement.childNodes[1].nodeName === "#text" &&
+        baseElement.childNodes[1].textContent.trim() === text
+    ) {
+        return replaceTextNodeWithDomElementForUsername(baseElement, 1);
+    }
+    else if (
         baseElement.childNodes.length === 3 &&
         baseElement.childNodes[0].nodeName === "#text" &&
         baseElement.childNodes[1].nodeName === "IMG" &&
         baseElement.childNodes[2].nodeName === "#text" &&
         baseElement.childNodes[2].textContent.trim() === text
     ) {
-        // sometimes text is directly after the user icon w/o separate html tag
-        // however, a real element is needed (not only a text node; a data-attribute will be set on the element later)
         return replaceTextNodeWithDomElementForUsername(baseElement, 2);
     } else {
         for (const child of baseElement.childNodes) {


### PR DESCRIPTION
There already is some code for "sometimes text is directly after the user icon w/o separate html tag" that tests for `["#text", "IMG", "#text"]`. This PR also covers `["IMG", "#text"]` (used e.g., in GitHub Actions pane `Triggered via push 3 hours ago, <UserID> pushed 4e7cde3`, `https://<host>/<org>/<repo>/actions/runs/<ID>`).