### PR TITLE
Add queries for Projects (beta) Boards: tooltips and group name

### DIFF
--- a/content_scripts/github/username.js
+++ b/content_scripts/github/username.js
@@ -73,9 +73,12 @@ function initializeGitHubIdQueries() {
     // projects (beta): card assignee tooltip
     _addTooltipQuery(`projects-v2 div[data-testid="board-card-header"] figure img[aria-describedby]`, { ariaDescribedbyRef: true });
     // projects (beta): roadmap assignee tooltip
-    _addTooltipQuery(`projects-v2 div[data-testid="roadmap-view-item-pill-content"] figure img[aria-describedby]`, { ariaDescribedbyRef: true });
+    _addTooltipQuery(
+        `projects-v2 div[data-testid="roadmap-view-item-pill-content"] figure[data-testid="roadmap-item-assignees"] img[aria-describedby]`,
+        { ariaDescribedbyRef: true }
+    );
     // projects (beta): roadmap group name
-    _addQuery(`projects-v2 span[data-testid="table-group-name"]`, { hrefException: true });
+    _addQuery(`projects-v2 span[class*="AvatarStack__AvatarStackWrapper"] + span[data-testid="table-group-name"]`, { hrefException: true });
     // projects (beta): archived items list item
     _addQuery(`projects-v2 main ul[data-testid="archived-item-list"] li div relative-time + span`, { hrefException: true });
     // wiki revisions history


### PR DESCRIPTION
Two rules for Projects (beta) **Boards**:
- Tooltip in board lanes 
- Group header (grouped by assignee)

![](https://i0.wp.com/user-images.githubusercontent.com/101840513/215615356-81a6b3f4-0555-4ff9-9c97-8e3337983a90.jpg?ssl=1)