### PR TITLE
Add rule for reaction tooltips

### DIFF
--- a/content_scripts/github/username.js
+++ b/content_scripts/github/username.js
@@ -134,6 +134,7 @@ function initializeGitHubIdQueries() {
 
     // tooltips (reactions)
     _addTooltipQuery(`tool-tip[for^=reactions--reaction_button_component-]`);
+    _addTooltipQuery(`button[data-testid="all-reactions-button"] + span[role="tooltip"]`);
     // tooltips: dashboard -> your teams -> popup (team member profile pictures)
     _addTooltipQuery(`div.AvatarStack div.AvatarStack-body.tooltipped`);
     // tooltips of 3+ committers

--- a/content_scripts/github/username.js
+++ b/content_scripts/github/username.js
@@ -134,7 +134,7 @@ function initializeGitHubIdQueries() {
 
     // tooltips (reactions)
     _addTooltipQuery(`tool-tip[for^=reactions--reaction_button_component-]`);
-    _addTooltipQuery(`button[data-testid="all-reactions-button"] + span[role="tooltip"]`);
+    _addTooltipQuery(`button[data-testid="all-reactions-button"] ~ span[role="tooltip"]`);
     // tooltips: dashboard -> your teams -> popup (team member profile pictures)
     _addTooltipQuery(`div.AvatarStack div.AvatarStack-body.tooltipped`);
     // tooltips of 3+ committers


### PR DESCRIPTION
Adds a rule for reaction tooltips (seen in projects beta issue details).

![image](https://github.com/nikolockenvitz/sap-addon/assets/12428377/f3ab640f-e1ae-41e0-910a-f82b9f71785e)