### PR TITLE
Replace username (in parentheses) with userId

### DIFF
--- a/content_scripts/github/username.js
+++ b/content_scripts/github/username.js
@@ -252,6 +252,7 @@ async function _replaceElementIfUserId(element) {
         }
         if (username) {
             const el = getDirectParentOfText(element, prefix + userId + suffix);
+            // replace userId with username
             if (el) {
                 el.textContent = prefix + username + suffix;
                 el.setAttribute("data-sap-addon-user-id", prefix + userId + suffix);
@@ -260,6 +261,14 @@ async function _replaceElementIfUserId(element) {
                     const currentWidth = element.parentElement.getBoundingClientRect().width;
                     const offsetLeft = parseFloat(element.parentElement.style.left);
                     element.parentElement.style.left = `${offsetLeft + (previousWidthInsightPulseTooltip - currentWidth) / 2}px`;
+                }
+            }
+            // replace username (in parentheses) with userId
+            if (el && el.nextSibling && el.nextSibling.classList.contains("css-truncate")) {
+                const truncateTarget = el.nextSibling.querySelector(".css-truncate-target");
+                if (truncateTarget && truncateTarget.textContent === `(${username})`) {
+                    truncateTarget.textContent = `(${userId})`;
+                    truncateTarget.setAttribute("data-sap-addon-user-id", `(${username})`);
                 }
             }
         }

--- a/content_scripts/github/username.js
+++ b/content_scripts/github/username.js
@@ -251,11 +251,11 @@ async function _replaceElementIfUserId(element) {
             username = await _getUsername(userId);
         }
         if (username) {
-            const el = getDirectParentOfText(element, prefix + userId + suffix);
             // replace userId with username
-            if (el) {
-                el.textContent = prefix + username + suffix;
-                el.setAttribute("data-sap-addon-user-id", prefix + userId + suffix);
+            const idToNameElement = getDirectParentOfText(element, prefix + userId + suffix);
+            if (idToNameElement) {
+                idToNameElement.textContent = prefix + username + suffix;
+                idToNameElement.setAttribute("data-sap-addon-user-id", prefix + userId + suffix);
 
                 if (previousWidthInsightPulseTooltip) {
                     const currentWidth = element.parentElement.getBoundingClientRect().width;
@@ -263,12 +263,12 @@ async function _replaceElementIfUserId(element) {
                     element.parentElement.style.left = `${offsetLeft + (previousWidthInsightPulseTooltip - currentWidth) / 2}px`;
                 }
             }
-            // replace username (in parentheses) with userId
-            if (el && el.nextSibling && el.nextSibling.classList.contains("css-truncate")) {
-                const truncateTarget = el.nextSibling.querySelector(".css-truncate-target");
-                if (truncateTarget && truncateTarget.textContent === `(${username})`) {
-                    truncateTarget.setAttribute("data-sap-addon-user-id", truncateTarget.textContent);
-                    truncateTarget.textContent = `(${userId})`;
+            // replace username with userId
+            const nameToIdElement = element.parentElement.querySelector(".css-truncate > .css-truncate-target");
+            if (nameToIdElement && nameToIdElement.textContent.includes(username)) {
+                if (!nameToIdElement.hasAttribute("data-sap-addon-user-id")) {
+                    nameToIdElement.setAttribute("data-sap-addon-user-id", nameToIdElement.textContent);
+                    nameToIdElement.textContent = nameToIdElement.textContent.replace(username, userId);
                 }
             }
         }

--- a/content_scripts/github/username.js
+++ b/content_scripts/github/username.js
@@ -267,8 +267,8 @@ async function _replaceElementIfUserId(element) {
             if (el && el.nextSibling && el.nextSibling.classList.contains("css-truncate")) {
                 const truncateTarget = el.nextSibling.querySelector(".css-truncate-target");
                 if (truncateTarget && truncateTarget.textContent === `(${username})`) {
+                    truncateTarget.setAttribute("data-sap-addon-user-id", truncateTarget.textContent);
                     truncateTarget.textContent = `(${userId})`;
-                    truncateTarget.setAttribute("data-sap-addon-user-id", `(${username})`);
                 }
             }
         }


### PR DESCRIPTION
"Show Names" disabled:
![image](https://github.com/nikolockenvitz/sap-addon/assets/12428377/71d84db3-dd20-464d-a204-0bda72fa2acb)

"Show Names" enabled (previously):
![image](https://github.com/nikolockenvitz/sap-addon/assets/12428377/a3ae7209-9259-4ea0-b3f5-92cc0c6e87ce)

With this PR, if a `UserID (User Name)` pair is present, the extension will also replace the username (in parentheses) with the userId:

**"Show Names" enabled (now)**:
![image](https://github.com/nikolockenvitz/sap-addon/assets/12428377/a754536a-9b49-4c1d-9cdb-7958b3955020)

---

**Please note 1**: For the "Show Names" feature toggle to work, the `"data-sap-addon-user-id"` attributed is used, but - contrary to its name - contains the value `(${username})`. Maybe `data-sap-addon-original-value` would be a more suitable name then.

**Please note 2**: During testing, I noticed that the "Show Names" toggle works fine for enabled→disabled and for disabled→enabled, but not for enabled→disabled→enabled with `TimelineItem`s. This is independent of the changes in this PR.
