### PR TITLE
gh: add rule for conversation links in PR

### DIFF
--- a/content_scripts/github/username.js
+++ b/content_scripts/github/username.js
@@ -44,6 +44,8 @@ function initializeGitHubIdQueries() {
     );
     // PR: "xyz requested your review" box
     _addQuery(`div#repo-content-pjax-container div.flash.flash-warn div a.text-emphasized.Link--primary`);
+    // PR: "Files changed" > "Conversations"
+    _addQuery(`a.js-conversations-menu-item div.d-flex img.avatar + span`);
     // hovercard
     _addQuery(`div.Popover-message section + section a.text-bold.Link--primary`)
     // projects (classic): card/issue creator


### PR DESCRIPTION
Adds a rule for GitHub > Pull Requests > Files Changed > Conversations > Jump to Conversation

![image](https://github.com/nikolockenvitz/sap-addon/assets/12428377/b47b7058-6612-4db2-bf84-fa3fdc0f7b8e)
