### PR TITLE
Rules for Reviewers list tooltips

### DIFF
--- a/content_scripts/github/username.js
+++ b/content_scripts/github/username.js
@@ -151,6 +151,9 @@ function initializeGitHubIdQueries() {
 
     // tooltips (reactions)
     _addTooltipQuery(`tool-tip[for^=reactions--reaction_button_component-]`);
+    _addTooltipQuery(`tool-tip[for^=awaiting-review-]`);
+    _addTooltipQuery(`tool-tip[for^=review-status-]`);
+    _addTooltipQuery(`tool-tip[for^=codeowner-]`);
     _addTooltipQuery(`button[data-testid="all-reactions-button"] ~ span[role="tooltip"]`);
     // tooltips: dashboard -> your teams -> popup (team member profile pictures)
     _addTooltipQuery(`div.AvatarStack div.AvatarStack-body.tooltipped`);
@@ -443,7 +446,15 @@ async function _getNewTooltipText(originalTooltipText) {
     // currently supports: emoji reactions, project issues cards
     // (A | A and B | A, B, and C) reacted with ... emoji
     // Assigned to (A | A and B | A, B, and C)
-    const tooltipTypes = [{ textAfterUserIds: " reacted with " }, { textBeforeUserIds: "Assigned to " }];
+    const tooltipTypes = [
+        { textAfterUserIds: " reacted with " }, 
+        { textBeforeUserIds: "Assigned to " },
+        { textBeforeUserIds: "Awaiting requested review from " },
+        { textAfterUserIds: " is a code owner" },
+        { textAfterUserIds: " approved these changes" },
+        { textAfterUserIds: " requested changes" },
+        { textAfterUserIds: " left review comments" }
+    ];
     let currentTooltipType;
     for (const tooltipType of tooltipTypes) {
         if (


### PR DESCRIPTION
Add some rules to match tooltips for the "Reviewers" list in pull requests.

![image](https://github.com/user-attachments/assets/def40955-fc3f-432b-93ba-321c6bd1e727)

- "Awaiting requested review from "
- " is a code owner"
- " approved these changes"
- " requested changes"
- " left review comments"
