### PR TITLE
Add name resolution for `splice by assignee` in project-v2

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,0 @@
-theme: jekyll-theme-cayman
-title: SAP Addon
-description: Firefox/Chrome Extension for SAP internal webpages

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+theme: jekyll-theme-cayman
+title: SAP Addon
+description: Firefox/Chrome Extension for SAP internal webpages

--- a/content_scripts/github/username.js
+++ b/content_scripts/github/username.js
@@ -84,6 +84,8 @@ function initializeGitHubIdQueries() {
             hrefException: true,
         }
     );
+    // projects (beta)L splice by assignees
+    _addQuery(`projects-v2 div[data-testid^="slicer-panel"] div > ul > li span h3"`, { hrefException: true });
     // projects (beta): card assignee tooltip
     _addTooltipQuery(`projects-v2 div[data-testid="board-card-header"] figure img[aria-describedby]`, { ariaDescribedbyRef: true });
     // projects (beta): roadmap assignee tooltip

--- a/content_scripts/github/username.js
+++ b/content_scripts/github/username.js
@@ -84,8 +84,13 @@ function initializeGitHubIdQueries() {
             hrefException: true,
         }
     );
-    // projects (beta): splice by assignees
-    _addQuery(`projects-v2 div[data-testid^="slicer-panel"] div > ul > li span h3"`, { hrefException: true });
+    // projects (beta): slice by assignees
+    _addQuery(
+        `projects-v2 div[data-testid="slicer-panel"] li div.actionlistitem-leadingcontent:has(div > img[data-testid="github-avatar"]) + div > div > h3`,
+        {
+            hrefException: true,
+        }
+    );
     // projects (beta): card assignee tooltip
     _addTooltipQuery(`projects-v2 div[data-testid="board-card-header"] figure img[aria-describedby]`, { ariaDescribedbyRef: true });
     // projects (beta): roadmap assignee tooltip

--- a/content_scripts/github/username.js
+++ b/content_scripts/github/username.js
@@ -84,7 +84,7 @@ function initializeGitHubIdQueries() {
             hrefException: true,
         }
     );
-    // projects (beta)L splice by assignees
+    // projects (beta): splice by assignees
     _addQuery(`projects-v2 div[data-testid^="slicer-panel"] div > ul > li span h3"`, { hrefException: true });
     // projects (beta): card assignee tooltip
     _addTooltipQuery(`projects-v2 div[data-testid="board-card-header"] figure img[aria-describedby]`, { ariaDescribedbyRef: true });


### PR DESCRIPTION
Hey @nikolockenvitz,

Here is a quick PR to add a query for `splice by assignee` in project-v2 (as requested in https://github.com/nikolockenvitz/sap-addon/issues/33).

I tested it with `document.querySelector()` and it seems to work, but TBH I couldn't make it work with the add-on installed locally on my Chrome (got lost of errors).  + it's been a while since I did some web stuff and I never worked with CSS selector.

Please feel free to make changes and test it (I can send you a link in DM to our project dashboard in github.tools.sap).