### PR TITLE
Add additional queries for pending deployments requested by username

### DIFF
--- a/content_scripts/github/username.js
+++ b/content_scripts/github/username.js
@@ -65,8 +65,8 @@ function initializeGitHubIdQueries() {
     _addQuery(`div.Popover-message section + section a.text-bold.Link--primary`);
     // deployments: "branch is waiting to be deployed" "by", "Deployment protection rules" "requested review", "Review pending deployments" "requested by"
     _addQuery(`div.branch-action div.merge-status-list a.text-bold`);
-    _addQuery(`div.actions-fullwidth-module a.text-bold`);
-    _addQuery(`dialog div.Overlay-header h3 div span.text-semibold`, { hrefException: true });
+    _addQuery(`div.actions-fullwidth-module > table td > div > div:has(img.avatar) + div > a.text-bold.Link--primary`);
+    _addQuery(`dialog div.Overlay-header h3 div span.text-semibold:first-child`, { hrefException: true });
     // projects (classic): card/issue creator
     _addQuery(`div.project-column div.d-flex small.color-fg-muted a.color-fg-default`);
     _addQuery(`div.d-flex div.js-project-issue-details-container small.color-fg-muted a.color-fg-default`);


### PR DESCRIPTION
Add additional queries for [pending deployments](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/review-deployments):
- org/repo/pull/123 
  - _This branch is waiting to be deployed_ → _Waiting 23 minutes ago by **User Name** via approve-deployment_
- org/repo/actions/runs/12345
  - _Deployment protection rules_ → _Event_ → _**User Name** requested review_
  - _User Name requested your review to deploy to the-environment_ → _Review deployments_ → _Review pending deployments requested by **User Name** in Action Name #2345_